### PR TITLE
Updated AC style to hide home page title via clip...

### DIFF
--- a/lai/css/academic_commons/homepage.css
+++ b/lai/css/academic_commons/homepage.css
@@ -36,7 +36,7 @@
   margin-left: .5em;
 }
 
-.block-lai-page-title h1 {
+.path-frontpage .block-lai-page-title h1 {
   clip-path: inset(100%);
   clip: rect(1px 1px 1px 1px);
   /* IE 6/7 */

--- a/lai/css/academic_commons/homepage.css
+++ b/lai/css/academic_commons/homepage.css
@@ -27,13 +27,24 @@
   margin: 0;
 }
 .path-frontpage #search-block-form div:first-child input {
-  padding: 0.5em;
+  padding: .5em;
   width: 100%;
   box-sizing: border-box;
 }
 .path-frontpage #search-block-form div:last-child {
   /* search button wrapper */
-  margin-left: 0.5em;
+  margin-left: .5em;
 }
 
-/*# sourceMappingURL=homepage.css.map */
+.block-lai-page-title h1 {
+  clip-path: inset(100%);
+  clip: rect(1px 1px 1px 1px);
+  /* IE 6/7 */
+  clip: rect(1px, 1px, 1px, 1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  /* added line */
+  width: 1px;
+}

--- a/lai/css/academic_commons/homepage.css.map
+++ b/lai/css/academic_commons/homepage.css.map
@@ -1,1 +1,0 @@
-{"version":3,"sourceRoot":"","sources":["homepage.scss","../_utilities.scss"],"names":[],"mappings":"AAGA;EACE;EACA;EACA;EACA;EACA;;AACA;EACE;;ACCF;EDRF;IAUI;IACA;IACA;;;ACJF;EDRF;IAeI;IACA;;;AAEF;AAAkB;EAChB;EACA;;AACA;EACE;EACA;EACA;;AAGJ;AAAiB;EACd","file":"homepage.css"}

--- a/lai/css/academic_commons/homepage.scss
+++ b/lai/css/academic_commons/homepage.scss
@@ -33,15 +33,15 @@
   }
 }
 
-.block-lai-page-title {
-	h1 { 
-		clip-path: inset(100%);
-		clip: rect(1px 1px 1px 1px); /* IE 6/7 */
-		clip: rect(1px, 1px, 1px, 1px);
-		height: 1px;
-		overflow: hidden;
-		position: absolute;
-		white-space: nowrap; /* added line */
-		width: 1px;
-	}
+.path-frontpage .block-lai-page-title {
+  h1 { 
+    clip-path: inset(100%);
+    clip: rect(1px 1px 1px 1px); /* IE 6/7 */
+    clip: rect(1px, 1px, 1px, 1px);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap; /* added line */
+    width: 1px;
+  }
 }

--- a/lai/css/academic_commons/homepage.scss
+++ b/lai/css/academic_commons/homepage.scss
@@ -32,3 +32,16 @@
      margin-left: .5em;
   }
 }
+
+.block-lai-page-title {
+	h1 { 
+		clip-path: inset(100%);
+		clip: rect(1px 1px 1px 1px); /* IE 6/7 */
+		clip: rect(1px, 1px, 1px, 1px);
+		height: 1px;
+		overflow: hidden;
+		position: absolute;
+		white-space: nowrap; /* added line */
+		width: 1px;
+	}
+}


### PR DESCRIPTION
(re: accessbility-friendly hide of homepage h1; request /issues/35 )

Will also need update block configuration once style has been applied ("Page title" block [admin/structure/block/manage/lai_page_title] -> Pages to show title for all pages).