### PR TITLE
Release 002 (tutoring instead of coaching)

### DIFF
--- a/lai/templates/search-result.html.twig
+++ b/lai/templates/search-result.html.twig
@@ -59,7 +59,7 @@
 #}
 {{ title_prefix }}
 <h3{{ title_attributes }}>
-  <a href="{{ url | replace({ '/fellowships-old':'/fellowships', '/peer-coaching-old':'/peer-coaching', '/workshops-academic-events-old':'/workshops-academic-events'}) }}">{{ title }}</a>
+  <a href="{{ url | replace({ '/fellowships-old':'/fellowships', '/tutoring-old':'/tutoring', '/workshops-academic-events-old':'/workshops-academic-events'}) }}">{{ title }}</a>
 </h3>
 {{ title_suffix }}
 {% if snippet %}

--- a/lai/templates/views-view-field--nothing.html.twig
+++ b/lai/templates/views-view-field--nothing.html.twig
@@ -2,7 +2,7 @@
 /**
  * @file
  * Theme override for a single field in a view.
- * Maxs: This overrides the links going to the assigned pages for 'Fellowships', 'Peer Coaching', and 'Workshops & Academic Event' and instead sends them to the customized versions
+ * Maxs: This overrides the links going to the assigned pages for 'Fellowships', 'Peer Tutoring', and 'Workshops & Academic Event' and instead sends them to the customized versions
  *
  * Available variables:
  * - view: The view that the field belongs to.
@@ -21,4 +21,4 @@
  * @ingroup themeable
  */
 #}
-{{ output | replace({ '/fellowships-old':'/fellowships', '/peer-coaching-old':'/peer-coaching', '/workshops-academic-events-old':'/workshops-academic-events' }) | raw }}
+{{ output | replace({ '/fellowships-old':'/fellowships', '/tutoring-old':'/tutoring', '/workshops-academic-events-old':'/workshops-academic-events' }) | raw }}

--- a/release-notes.md
+++ b/release-notes.md
@@ -10,3 +10,6 @@ Started as of September 11, 2018
 * Hide homepage h1 visually but still accessible to screen readers (fixes [35](../../issues/35))
 * Adjust styling for new Views output of buckets as wrapped in <a>s (and remove JS formerly meant to make these more linky) (fixes [29](../../issues/29))
 * More robust output and CSS for individual fellowship pages (fixes [33](../../issues/33))
+
+2019/01/10
+* Update twig templates that redirect traffic to custom pages to use the /tutoring URI instead of /peer-coaching (fixes [41](../../issues/41))


### PR DESCRIPTION
Updating the theme hack that changes instances of "custom-page-old" to point to "custom-page" instead, using new "tutoring" URI instead of old "peer-coaching" one (fixes #41).

Requires changes to AC module and data/content, most importantly the URL alias of /node/22/edit should be changed to "tutoring-old", and the redirect currently going from "/tutoring" to "/peer-coaching" should be changed to the inverse (or deleted and re-added as the other way or whatever).