### PR TITLE
Hack for new field info to be displayed inside a Calendly popup

### DIFF
--- a/lai/css/academic_commons/peer-coaching.css
+++ b/lai/css/academic_commons/peer-coaching.css
@@ -24,4 +24,10 @@
   margin-top: 0.25em;
 }
 
+/* Hack to hide this field when not displayed through the Calendly popup hack
+   #content to make things more specific (else some other oddly-specific selector) */
+#content .peer_coaching_appointment_rsvp__review-session-info {
+  display: none;
+}
+
 /*# sourceMappingURL=peer-coaching.css.map */

--- a/lai/css/academic_commons/peer-coaching.scss
+++ b/lai/css/academic_commons/peer-coaching.scss
@@ -30,3 +30,9 @@
 #peer-coaching-event-info h2 {
   margin-top: .25em;
 }
+
+/* Hack to hide this field when not displayed through the Calendly popup hack
+   #content to make things more specific (else some other oddly-specific selector) */
+#content .peer_coaching_appointment_rsvp__review-session-info {
+  display: none;
+}

--- a/lai/css/import-all.css
+++ b/lai/css/import-all.css
@@ -8,3 +8,7 @@
 @import url("academic_commons/events.css");
 @import url("academic_commons/webforms.css");
 @import url("academic_commons/peer-coaching.css");
+
+div.content .peer_coaching_appointment_rsvp__review-session-info {
+  display: none;
+}

--- a/lai/css/import-all.css
+++ b/lai/css/import-all.css
@@ -8,7 +8,3 @@
 @import url("academic_commons/events.css");
 @import url("academic_commons/webforms.css");
 @import url("academic_commons/peer-coaching.css");
-
-div.content .peer_coaching_appointment_rsvp__review-session-info {
-  display: none;
-}

--- a/lai/js/build/peer-coaching.js
+++ b/lai/js/build/peer-coaching.js
@@ -1,8 +1,22 @@
 (function ($) {
 
   // This makes the Calendly link pop open in the same window since Views strips out onclick attributes
-  $('.peer-coaching-detail a[href*="calendly"]').each(function() {
+  // It used to use `a[href*="calendly"]` but we also want to hack something together for non-Calendly links (see below)
+  $('.peer-coaching-detail a:first').each(function() {
     $(this).attr("onclick","Calendly.showPopupWidget('" + $(this).attr("href") + "');return false;");
   });
+
+  // Hack to reuse popup intended for Calendly links to now also show the value of the "Review Session Info" field
+  if (window.self != window.top) {
+    // If inside an iframe, hide elements like headers and footers that make for possible infinite nesting and linking from within the iframe we'd rather avoid
+    $(".peer_coaching_appointment_rsvp").on("load", "#toolbar-administration, .region-header, #block-lai-page-title, #block-lai-local-tasks, #block-views-block-peer-coaching-detail-block-1, .region-footer, #drupal-live-announce, #block-academiccommonsfooter", function() {
+      // doing as delegated .on("load") instead of .find() since #block-academiccommonsfooter (at least) doesn't seem to load at same time as the rest of the page
+      $(this).hide();
+    });
+    // Though do turn on the field we normally hide in display if somebody lands on the node from search
+    $(".peer_coaching_appointment_rsvp .peer_coaching_appointment_rsvp__review-session-info").show();
+    // Make sure any links within the field, such as to other GW departments, open in a new tab instead of possibly within the iframe
+    $(".peer_coaching_appointment_rsvp #content a").attr("target","_blank");
+  }
 
 })(jQuery);

--- a/lai/js/build/peer-coaching.js
+++ b/lai/js/build/peer-coaching.js
@@ -9,10 +9,8 @@
   // Hack to reuse popup intended for Calendly links to now also show the value of the "Review Session Info" field
   if (window.self != window.top) {
     // If inside an iframe, hide elements like headers and footers that make for possible infinite nesting and linking from within the iframe we'd rather avoid
-    $(".peer_coaching_appointment_rsvp").on("load", "#toolbar-administration, .region-header, #block-lai-page-title, #block-lai-local-tasks, #block-views-block-peer-coaching-detail-block-1, .region-footer, #drupal-live-announce, #block-academiccommonsfooter", function() {
-      // doing as delegated .on("load") instead of .find() since #block-academiccommonsfooter (at least) doesn't seem to load at same time as the rest of the page
-      $(this).hide();
-    });
+    // Doing as injected <style> instead of .find() since #block-academiccommonsfooter (at least) doesn't seem to load at same time as the rest of the page
+    $(".peer_coaching_appointment_rsvp").prepend("<style type='text/css'>#toolbar-administration, .region-header, #block-lai-page-title, #block-lai-local-tasks, #block-views-block-peer-coaching-detail-block-1, .region-footer, #drupal-live-announce, #block-academiccommonsfooter { display: none; } </style>");
     // Though do turn on the field we normally hide in display if somebody lands on the node from search
     $(".peer_coaching_appointment_rsvp .peer_coaching_appointment_rsvp__review-session-info").show();
     // Make sure any links within the field, such as to other GW departments, open in a new tab instead of possibly within the iframe


### PR DESCRIPTION
This theme code change is basically expecting a new field in the Peer Coaching Appointment/RSVP content type (machine name: review_session_info), which in a normal display it hides, but within a popup/iframe (both from the /tutoring page or when clicking the first link on the node page created by the view override there), it displays _only_ that new field and hides everything else. It also adds target="_blank" to any links in said popup so that links in that field (typically to other GW deparments) won't possibly open within the iframe. I originally had some code checking whether the window.parent was on the same server (in case the AC site was somehow reached from within somebody else's frames), but it seems something either in Drupal or Apache is denying such x-frame-options anyway.

**Non-code requirements**: new field in the Peer Coaching Appointment/RSVP content type **with machine name: field_review_session_info**, with manage display set to show the field but label hidden. (Some ymls attached for suggested wording of things like labels and helper text.)

~~[calendly-hack-review-session-ymls-02.zip](https://github.com/gwu-libraries/academiccommons-theme/files/2829694/calendly-hack-review-session-ymls-02.zip)~~ (see better ymls in comment below).

~~My least favorite part about this hack is that it requires people publish the node without something in the Link field, then go back and re-add `/node/NNN` (copied from the URL) into it. Not sure of way around that (besides something like adding a different content type, which seems to require yet more hacking/ugliness).~~ This should no longer be required assuming gwu-libraries/Drupal-Modules#159 also gets deployed.