### PR TITLE
Release 003 (Calendly popup hack)

### DIFF
--- a/lai/css/academic_commons/peer-coaching.css
+++ b/lai/css/academic_commons/peer-coaching.css
@@ -24,4 +24,10 @@
   margin-top: 0.25em;
 }
 
+/* Hack to hide this field when not displayed through the Calendly popup hack
+   #content to make things more specific (else some other oddly-specific selector) */
+#content .peer_coaching_appointment_rsvp__review-session-info {
+  display: none;
+}
+
 /*# sourceMappingURL=peer-coaching.css.map */

--- a/lai/css/academic_commons/peer-coaching.scss
+++ b/lai/css/academic_commons/peer-coaching.scss
@@ -30,3 +30,9 @@
 #peer-coaching-event-info h2 {
   margin-top: .25em;
 }
+
+/* Hack to hide this field when not displayed through the Calendly popup hack
+   #content to make things more specific (else some other oddly-specific selector) */
+#content .peer_coaching_appointment_rsvp__review-session-info {
+  display: none;
+}

--- a/lai/css/import-all.css
+++ b/lai/css/import-all.css
@@ -8,3 +8,7 @@
 @import url("academic_commons/events.css");
 @import url("academic_commons/webforms.css");
 @import url("academic_commons/peer-coaching.css");
+
+div.content .peer_coaching_appointment_rsvp__review-session-info {
+  display: none;
+}

--- a/lai/css/import-all.css
+++ b/lai/css/import-all.css
@@ -8,7 +8,3 @@
 @import url("academic_commons/events.css");
 @import url("academic_commons/webforms.css");
 @import url("academic_commons/peer-coaching.css");
-
-div.content .peer_coaching_appointment_rsvp__review-session-info {
-  display: none;
-}

--- a/lai/js/build/peer-coaching.js
+++ b/lai/js/build/peer-coaching.js
@@ -1,8 +1,22 @@
 (function ($) {
 
   // This makes the Calendly link pop open in the same window since Views strips out onclick attributes
-  $('.peer-coaching-detail a[href*="calendly"]').each(function() {
+  // It used to use `a[href*="calendly"]` but we also want to hack something together for non-Calendly links (see below)
+  $('.peer-coaching-detail a:first').each(function() {
     $(this).attr("onclick","Calendly.showPopupWidget('" + $(this).attr("href") + "');return false;");
   });
+
+  // Hack to reuse popup intended for Calendly links to now also show the value of the "Review Session Info" field
+  if (window.self != window.top) {
+    // If inside an iframe, hide elements like headers and footers that make for possible infinite nesting and linking from within the iframe we'd rather avoid
+    $(".peer_coaching_appointment_rsvp").on("load", "#toolbar-administration, .region-header, #block-lai-page-title, #block-lai-local-tasks, #block-views-block-peer-coaching-detail-block-1, .region-footer, #drupal-live-announce, #block-academiccommonsfooter", function() {
+      // doing as delegated .on("load") instead of .find() since #block-academiccommonsfooter (at least) doesn't seem to load at same time as the rest of the page
+      $(this).hide();
+    });
+    // Though do turn on the field we normally hide in display if somebody lands on the node from search
+    $(".peer_coaching_appointment_rsvp .peer_coaching_appointment_rsvp__review-session-info").show();
+    // Make sure any links within the field, such as to other GW departments, open in a new tab instead of possibly within the iframe
+    $(".peer_coaching_appointment_rsvp #content a").attr("target","_blank");
+  }
 
 })(jQuery);

--- a/lai/js/build/peer-coaching.js
+++ b/lai/js/build/peer-coaching.js
@@ -9,10 +9,8 @@
   // Hack to reuse popup intended for Calendly links to now also show the value of the "Review Session Info" field
   if (window.self != window.top) {
     // If inside an iframe, hide elements like headers and footers that make for possible infinite nesting and linking from within the iframe we'd rather avoid
-    $(".peer_coaching_appointment_rsvp").on("load", "#toolbar-administration, .region-header, #block-lai-page-title, #block-lai-local-tasks, #block-views-block-peer-coaching-detail-block-1, .region-footer, #drupal-live-announce, #block-academiccommonsfooter", function() {
-      // doing as delegated .on("load") instead of .find() since #block-academiccommonsfooter (at least) doesn't seem to load at same time as the rest of the page
-      $(this).hide();
-    });
+    // Doing as injected <style> instead of .find() since #block-academiccommonsfooter (at least) doesn't seem to load at same time as the rest of the page
+    $(".peer_coaching_appointment_rsvp").prepend("<style type='text/css'>#toolbar-administration, .region-header, #block-lai-page-title, #block-lai-local-tasks, #block-views-block-peer-coaching-detail-block-1, .region-footer, #drupal-live-announce, #block-academiccommonsfooter { display: none; } </style>");
     // Though do turn on the field we normally hide in display if somebody lands on the node from search
     $(".peer_coaching_appointment_rsvp .peer_coaching_appointment_rsvp__review-session-info").show();
     // Make sure any links within the field, such as to other GW departments, open in a new tab instead of possibly within the iframe

--- a/release-notes.md
+++ b/release-notes.md
@@ -13,3 +13,6 @@ Started as of September 11, 2018
 
 2019/01/10
 * Update twig templates that redirect traffic to custom pages to use the /tutoring URI instead of /peer-coaching (fixes [41](../../issues/41))
+
+2019/02/07
+* Hack to allow (along w/ config and AC modules changes) review session information to display in the same popup currently used for Calendly (fixes [44](../../issues/44))


### PR DESCRIPTION
This is basically the same as the changes in pull request #45 (since it's just this one issue/feature up for release this time around) plus the addition of release notes. 

These changes, and related YML imports[1], have been feature tested and regression tested (along with module and view changes as described in that repo) with nothing unexpected found. 

[1] Noting for posterity/good measure that of the [YML files needed for import](https://github.com/gwu-libraries/academiccommons-theme/files/2832804/calendly-hack-review-session-ymls-03.zip), the contents of the `field.storage` need to be imported first (minus the first UUID line), then `field.field` (also minus the first UUID line), then can do `core.entity_form_display` and `core.entity_view_display` (both with the UUID line intact). I'll add separate notes about the module-related import in the [module release pull request](https://github.com/gwu-libraries/Drupal-Modules/pull/160).