### PR TITLE
Release 004 (GDPR/cookie notice, tested with some module updates)

### DIFF
--- a/lai/css/gw_editorial/eu-cookie-compliance-overrides.css
+++ b/lai/css/gw_editorial/eu-cookie-compliance-overrides.css
@@ -1,0 +1,54 @@
+#popup-text a, #popup-text strong {
+  color: #fff;
+}
+#popup-text a {
+  text-decoration: underline;
+}
+
+#sliding-popup .popup-content {
+  margin: 0 auto;
+  display: flex;
+  width: 100%;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
+}
+#sliding-popup .popup-content #popup-text {
+  max-width: 80%;
+}
+@media screen and (max-width: 800px) {
+  #sliding-popup .popup-content #popup-text {
+    max-width: 95%;
+  }
+}
+#sliding-popup .popup-content #popup-text p {
+  font-size: 17px;
+  margin: 1em 0;
+  display: block;
+  line-height: 1.5em;
+}
+@media screen and (max-width: 800px) {
+  #sliding-popup .popup-content #popup-text p {
+    font-size: 15px;
+    margin: 0.5em 0 0;
+    line-height: 1.35em;
+  }
+}
+
+#sliding-popup #popup-buttons button {
+  font-family: inherit;
+  font-weight: normal;
+  background-color: #fff;
+  border-color: #004065;
+  padding: 5px 12px;
+  color: #004065;
+  display: inline-block;
+  margin: 0 1em;
+}
+@media screen and (max-width: 800px) {
+  #sliding-popup #popup-buttons button {
+    font-size: 15px;
+  }
+}
+
+/*# sourceMappingURL=eu-cookie-compliance-overrides.css.map */

--- a/lai/css/gw_editorial/eu-cookie-compliance-overrides.scss
+++ b/lai/css/gw_editorial/eu-cookie-compliance-overrides.scss
@@ -1,0 +1,48 @@
+#popup-text {
+  a, strong {
+    color: #fff;
+  }
+  a {
+    text-decoration: underline;
+  }
+}
+
+#sliding-popup .popup-content {
+  margin: 0 auto;
+  display: flex;
+  width: 100%;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
+  #popup-text {
+    max-width: 80%;
+    @media screen and (max-width: 800px) {
+      max-width: 95%;
+    }
+    p {
+      font-size: 17px;
+      margin: 1em 0;
+      display: block;
+      line-height: 1.5em;
+      @media screen and (max-width: 800px) {
+        font-size: 15px;
+        margin: .5em 0 0;
+        line-height: 1.35em;
+      }
+    }
+  }
+}
+
+#sliding-popup #popup-buttons button {
+  font-family: inherit;
+  font-weight: normal;
+  background-color: #fff;
+  border-color: #004065;
+  padding: 5px 12px;
+  color: #004065;
+  display: inline-block;
+  margin: 0 1em;
+  @media screen and (max-width: 800px) {
+    font-size: 15px;
+  }
+}

--- a/lai/css/import-all.css
+++ b/lai/css/import-all.css
@@ -1,5 +1,6 @@
 /* Created as a way to better share styling with CKEditor */
 @import url("gw_editorial/gwoverrides.css"); /* which itself imports other CSS files */
+@import url("gw_editorial/eu-cookie-compliance-overrides.css");
 @import url("libsite/custom.css");
 @import url("libsite/tabs.css");
 @import url("academic_commons/fellowships.css");

--- a/release-notes.md
+++ b/release-notes.md
@@ -17,5 +17,5 @@ Started as of September 11, 2018
 2019/02/07
 * Hack to allow (along w/ config and AC modules changes) review session information to display in the same popup currently used for Calendly (fixes [44](../../issues/44))
 
-2019/02/29
+2019/03/01
 * Add styling for the GDPR/cookie-related notice (fixes [47](../../issues/47))

--- a/release-notes.md
+++ b/release-notes.md
@@ -16,3 +16,6 @@ Started as of September 11, 2018
 
 2019/02/07
 * Hack to allow (along w/ config and AC modules changes) review session information to display in the same popup currently used for Calendly (fixes [44](../../issues/44))
+
+2019/02/29
+* Add styling for the GDPR/cookie-related notice (fixes [47](../../issues/47))

--- a/release-notes.md
+++ b/release-notes.md
@@ -17,5 +17,5 @@ Started as of September 11, 2018
 2019/02/07
 * Hack to allow (along w/ config and AC modules changes) review session information to display in the same popup currently used for Calendly (fixes [44](../../issues/44))
 
-2019/03/01
+2019/03/04
 * Add styling for the GDPR/cookie-related notice (fixes [47](../../issues/47))


### PR DESCRIPTION
This "release" just includes the following _AC theme_ ticket:
 * #47 GDPR/cookie notice (style overrides of the default CSS provided by the `eu_cookie_compliance` module)

But was tested at the same time as the following other updates on the AC site, passing regression testing completed by Ben and feature testing done by Quinn:
 * adding the actual `eu_cookie_compliance` module, of course
 * fixing course number order issue (see gwu-libraries/Drupal-Modules#90)
 * adjusting `trusted_host_patterns` in settings.php (intentionally not in a repo) so as to not have to update it every single time we put site clones on dev instances with wrlc.org domains
 * updating the following modules: drupal (aka core), ctools, better_exposed_filters, google_analytics, pathauto, recaptcha, svg_image, token, and webform